### PR TITLE
Fix missing options controller link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ popup/
 ?? popupstyles.css                 ? Responsive popup styling  
 options/  
 ?? optionsui.html                  ? Full options page markup  
-?? optionslogic.js                 ? Options page controller  
+?? optionsFormController.js       ? Options page controller
 ?? optionsstyles.css               ? Options page styling  
 icons/  
 ?? 16.png, 32.png, 48.png, 128.png ? *(to be added)*  
@@ -161,7 +161,7 @@ icons/
 - **popup.html / popuplogic.js / popupstyles.css**  
   Quick access UI for toggling the extension and adjusting multiplier range. Syncs with storage and updates badge.
 
-- **optionsui.html / optionslogic.js / optionsstyles.css**  
+- **optionsui.html / optionsFormController.js / optionsstyles.css**
   Full standalone options page with form controls, descriptions, tooltips, and ?Reset to Defaults? button.
 
 ---

--- a/installTabContentInjector.js
+++ b/installTabContentInjector.js
@@ -15,7 +15,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   ) {
     chrome.scripting.executeScript({
       target: { tabId },
-      files: ['src/content.js']
+      files: ['currencyMultiplierTextManager.js']
     }).catch((error) => {
       console.error('Failed to inject content script into tab', tabId, error);
     });

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     "https://appsumo.com/*"
   ],
   "background": {
-    "service_worker": "src/installTabContentInjector.js"
+    "service_worker": "installTabContentInjector.js"
   },
   "action": {
     "default_title": "Price Changer",

--- a/multiplierOptionsForm.html
+++ b/multiplierOptionsForm.html
@@ -21,6 +21,6 @@
     <span id="status" aria-live="polite"></span>
   </form>
 
-  <script src="optionslogic.js"></script>
+  <script src="optionsFormController.js"></script>
 </body>
 </html>

--- a/optionsFormController.js
+++ b/optionsFormController.js
@@ -1,5 +1,7 @@
 import * as storage from './settingsSyncManager.js';
 
+document.addEventListener('DOMContentLoaded', optionsInit);
+
 async function optionsInit() {
   const settings = await storage.getSettings();
   for (const [key, value] of Object.entries(settings)) {
@@ -69,4 +71,3 @@ async function handleSave(event) {
     }, 2000);
   }
 }
-})();


### PR DESCRIPTION
## Summary
- wire up optionsFormController on DOMContentLoaded
- load the correct controller in multiplierOptionsForm.html
- fix service worker path in manifest
- update content script injection path
- clarify README about options page script

## Testing
- `node --check optionsFormController.js`
- `node --check installTabContentInjector.js`

------
https://chatgpt.com/codex/tasks/task_e_6859d248fe30833087446c6632a96fbd