### PR TITLE
Modify review display and add dissuasion text

### DIFF
--- a/currencyMultiplierTextManager.js
+++ b/currencyMultiplierTextManager.js
@@ -1,6 +1,8 @@
 (function() {
     const priceRegex = /\$([\d,]+(?:\.\d{1,2})?)/g;
     const testRegex = /\$[\d,]+(?:\.\d{1,2})?/;
+    const reviewCountRegex = /(\b\d+(?:,\d+)*\b)(?=\s*reviews?)/i;
+    const ratingTextRegex = /(\b\d+(?:\.\d+)?\b)(?=\s*(?:tacos?|stars?))/i;
     const processedNodes = new WeakSet();
     let observer = null;
     let currentSettings = { minMultiplier: 1, maxMultiplier: 5, enabled: true };
@@ -31,12 +33,33 @@
         });
     }
 
+    function processReviewText(text) {
+        let updated = text.replace(reviewCountRegex, '999');
+        updated = updated.replace(ratingTextRegex, '1');
+        return updated;
+    }
+
     function handleTextNode(node, min, max) {
         if (processedNodes.has(node)) return;
-        if (!testRegex.test(node.textContent)) return;
-        const newText = processText(node.textContent, min, max);
-        if (newText !== node.textContent) {
-            replaceNodeText(node, newText);
+        let text = node.textContent;
+        let changed = false;
+
+        if (testRegex.test(text)) {
+            const replaced = processText(text, min, max);
+            if (replaced !== text) {
+                text = replaced;
+                changed = true;
+            }
+        }
+
+        const reviewReplaced = processReviewText(text);
+        if (reviewReplaced !== text) {
+            text = reviewReplaced;
+            changed = true;
+        }
+
+        if (changed) {
+            replaceNodeText(node, text);
             processedNodes.add(node);
         }
     }
@@ -64,6 +87,7 @@
         while (node = walker.nextNode()) {
             handleTextNode(node, min, max);
         }
+        updateRatingElements(document.body);
     }
 
     function observeMutations(min, max) {
@@ -95,11 +119,89 @@
                         while (subNode = walker.nextNode()) {
                             handleTextNode(subNode, min, max);
                         }
+                        updateRatingElements(node);
                     }
                 });
             }
         });
         observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    function updateRatingElements(root) {
+        const container = root instanceof Document ? root.body : root;
+        if (!container) return;
+        const ratingNodes = container.querySelectorAll('[aria-label*="taco" i], [aria-label*="rating" i], [class*="taco" i], [class*="rating" i]');
+        ratingNodes.forEach(el => {
+            if (el.dataset.ratingModified) return;
+            el.dataset.ratingModified = 'true';
+
+            const aria = el.getAttribute('aria-label');
+            if (aria) {
+                el.setAttribute('aria-label', processReviewText(aria));
+            }
+
+            const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+            let node;
+            while (node = walker.nextNode()) {
+                node.textContent = processReviewText(node.textContent);
+            }
+
+            const icons = el.querySelectorAll('svg, img, i, span');
+            icons.forEach((icon, idx) => {
+                if (idx === 0) return;
+                icon.remove();
+            });
+
+            if (icons.length === 0) {
+                el.textContent = '🌮';
+            }
+        });
+    }
+
+    const dissuadeMessages = [
+        'Are you sure you want this LTD?',
+        'Nobody like this tool',
+        'Think twice before buying.',
+        "Don't waste your money.",
+        'Join Ken Moo LTD group.'
+    ];
+    let lastScroll = 0;
+    let overlayDiv = null;
+
+    function createOverlay() {
+        overlayDiv = document.createElement('div');
+        overlayDiv.style.position = 'fixed';
+        overlayDiv.style.bottom = '10%';
+        overlayDiv.style.left = '50%';
+        overlayDiv.style.transform = 'translateX(-50%)';
+        overlayDiv.style.zIndex = '9999';
+        overlayDiv.style.fontSize = '2rem';
+        overlayDiv.style.fontWeight = 'bold';
+        overlayDiv.style.color = '#b00';
+        overlayDiv.style.background = 'rgba(255,255,255,0.9)';
+        overlayDiv.style.padding = '10px 20px';
+        overlayDiv.style.borderRadius = '8px';
+        overlayDiv.style.display = 'none';
+        overlayDiv.style.pointerEvents = 'none';
+        document.body.appendChild(overlayDiv);
+    }
+
+    function showOverlayMessage() {
+        if (!overlayDiv) createOverlay();
+        const msg = dissuadeMessages[Math.floor(Math.random() * dissuadeMessages.length)];
+        overlayDiv.textContent = msg;
+        overlayDiv.style.display = 'block';
+        clearTimeout(overlayDiv.hideTimer);
+        overlayDiv.hideTimer = setTimeout(() => {
+            overlayDiv.style.display = 'none';
+        }, 2000);
+    }
+
+    function onScroll() {
+        if (Math.abs(window.scrollY - lastScroll) > 200) {
+            lastScroll = window.scrollY;
+            showOverlayMessage();
+        }
     }
 
     function init() {
@@ -110,8 +212,12 @@
                 if (enabled) {
                     walkAndReplace(minMultiplier, maxMultiplier);
                     observeMutations(minMultiplier, maxMultiplier);
-                } else if (observer) {
-                    observer.disconnect();
+                    updateRatingElements(document.body);
+                    window.addEventListener('scroll', onScroll, { passive: true });
+                } else {
+                    if (observer) observer.disconnect();
+                    window.removeEventListener('scroll', onScroll);
+                    if (overlayDiv) overlayDiv.style.display = 'none';
                 }
             }
         );

--- a/currencyMultiplierTextManager.js
+++ b/currencyMultiplierTextManager.js
@@ -147,14 +147,11 @@
             }
 
             const icons = el.querySelectorAll('svg, img, i, span');
-            icons.forEach((icon, idx) => {
-                if (idx === 0) return;
-                icon.remove();
-            });
+            icons.forEach(icon => icon.remove());
 
-            if (icons.length === 0) {
-                el.textContent = '🌮';
-            }
+            const emoji = document.createElement('span');
+            emoji.textContent = '🌮';
+            el.insertBefore(emoji, el.firstChild);
         });
     }
 


### PR DESCRIPTION
## Summary
- modify content script to fake review counts and ratings
- inject random discouraging messages on scroll events
- ensure rating widgets display only a single taco icon

## Testing
- `node -c currencyMultiplierTextManager.js`


------
https://chatgpt.com/codex/tasks/task_e_6859dce6cb48833096d8e49921934de9